### PR TITLE
Skip file when key file is missing instead of aborting initialization

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -65,7 +65,8 @@ func (fs *stdFs) Reload(add func(key, name string)) error {
 
 		key, err := fs.getKey(f.Name())
 		if err != nil {
-			return err
+			fs.Remove(filepath.Join(fs.root, f.Name()))
+			continue
 		}
 		fi, ok := addfiles[key]
 


### PR DESCRIPTION
We have observed instances where .key files are missing but the main file still exists.  It's not entirely clear how this happens (file system corruption?), but in case it does, it makes sense just to delete the relevant file and continue, rather than aborting the entire initialization as happens currently.