### PR TITLE
Workflow and linting updates

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,9 +1,27 @@
-name: go test
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
+  pull_request:
+
 jobs:
-  call-workflow:
-    uses: djherbis/actions/.github/workflows/go-test.yml@main
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,8 +10,11 @@ on:
 
 jobs:
 
-  build:
-    runs-on: ubuntu-latest
+  build-test:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+.idea/
+*.iml
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work
 .idea/
 *.iml
 
+cache*/
+server/
+

--- a/distrib.go
+++ b/distrib.go
@@ -53,10 +53,9 @@ func (d *distrib) GetCache(key string) Cache {
 // It continues to clean even if one of the caches returns an error,
 // but will return the first error encountered.
 func (d *distrib) Clean() error {
-	var err1, err2 error
+	var err1 error
 	for _, c := range d.caches {
-		err2 = c.Clean()
-		if err2 != nil && err1 == nil {
+		if err2 := c.Clean(); err2 != nil && err1 == nil {
 			err1 = err2
 		}
 	}

--- a/distrib.go
+++ b/distrib.go
@@ -20,7 +20,7 @@ type Distributor interface {
 // stdDistribution distributes the keyspace evenly.
 func stdDistribution(key string, n uint64) uint64 {
 	h := sha1.New()
-	io.WriteString(h, key)
+	_, _ = io.WriteString(h, key)
 	buf := bytes.NewBuffer(h.Sum(nil)[:8])
 	i, _ := binary.ReadUvarint(buf)
 	return i % n
@@ -49,12 +49,18 @@ func (d *distrib) GetCache(key string) Cache {
 	return d.caches[d.distribution(key, d.size)]
 }
 
-// BUG(djherbis): Return an error if cleaning fails
+// Clean cleans all the caches this Distributor manages.
+// It continues to clean even if one of the caches returns an error,
+// but will return the first error encountered.
 func (d *distrib) Clean() error {
+	var err1, err2 error
 	for _, c := range d.caches {
-		c.Clean()
+		err2 = c.Clean()
+		if err2 != nil && err1 == nil {
+			err1 = err2
+		}
 	}
-	return nil
+	return err1
 }
 
 // NewPartition returns a Cache which uses the Caches defined by the passed Distributor.

--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,7 @@ func Example() {
 	}
 
 	// wipe the cache when done
+	defer os.RemoveAll("./cache")
 	defer c.Clean()
 
 	// Get() and it's streams can be called concurrently but just for example:
@@ -49,6 +50,7 @@ func ExampleHandler() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+	defer os.RemoveAll("./server")
 	defer c.Clean()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/fs.go
+++ b/fs.go
@@ -97,14 +97,14 @@ func (fs *StandardFS) Reload(add func(key, name string)) error {
 
 		key, err := fs.getKey(f.Name())
 		if err != nil {
-			fs.Remove(filepath.Join(fs.root, f.Name()))
+			_ = fs.Remove(filepath.Join(fs.root, f.Name()))
 			continue
 		}
 		fi, ok := addfiles[key]
 
 		if !ok || fi.ModTime().Before(f.ModTime()) {
 			if ok {
-				fs.Remove(fi.Name())
+				_ = fs.Remove(fi.Name())
 			}
 			addfiles[key] = struct {
 				os.FileInfo
@@ -114,7 +114,7 @@ func (fs *StandardFS) Reload(add func(key, name string)) error {
 				key:      key,
 			}
 		} else {
-			fs.Remove(f.Name())
+			_ = fs.Remove(f.Name())
 		}
 
 	}
@@ -195,8 +195,8 @@ const (
 func tob64(s string) string {
 	buf := bytes.NewBufferString("")
 	enc := base64.NewEncoder(base64.URLEncoding, buf)
-	enc.Write([]byte(s))
-	enc.Close()
+	_, _ = enc.Write([]byte(s))
+	_ = enc.Close()
 	return buf.String()
 }
 
@@ -204,7 +204,7 @@ func fromb64(s string) string {
 	buf := bytes.NewBufferString(s)
 	dec := base64.NewDecoder(base64.URLEncoding, buf)
 	out := bytes.NewBufferString("")
-	io.Copy(out, dec)
+	_, _ = io.Copy(out, dec)
 	return out.String()
 }
 

--- a/fscache.go
+++ b/fscache.go
@@ -184,8 +184,8 @@ func (c *FSCache) Get(key string) (r ReadAtCloser, w io.WriteCloser, err error) 
 
 	r, err = f.next()
 	if err != nil {
-		f.Close()
-		c.fs.Remove(f.Name())
+		_ = f.Close()
+		_ = c.fs.Remove(f.Name())
 		return nil, nil, err
 	}
 
@@ -237,7 +237,7 @@ func (a *accessor) RemoveFile(key string) {
 	f, ok := a.c.files[key]
 	delete(a.c.files, key)
 	if ok {
-		a.c.fs.Remove(f.Name())
+		_ = a.c.fs.Remove(f.Name())
 	}
 }
 

--- a/fscache_test.go
+++ b/fscache_test.go
@@ -19,8 +19,15 @@ func createFile(name string) (*os.File, error) {
 }
 
 func init() {
-	c, _ := NewCache(NewMemFs(), nil)
-	go ListenAndServe(c, "localhost:10000")
+	c, err := NewCache(NewMemFs(), nil)
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		if err := ListenAndServe(c, "localhost:10000"); err != nil {
+			panic(err)
+		}
+	}()
 }
 
 func testCaches(t *testing.T, run func(c Cache)) {

--- a/fscache_test.go
+++ b/fscache_test.go
@@ -29,6 +29,7 @@ func testCaches(t *testing.T, run func(c Cache)) {
 		t.Error(err.Error())
 		return
 	}
+	t.Cleanup(func() { os.RemoveAll("./cache") })
 	run(c)
 
 	c, err = NewCache(NewMemFs(), NewReaper(time.Hour, time.Hour))
@@ -48,6 +49,7 @@ func testCaches(t *testing.T, run func(c Cache)) {
 	run(rc)
 
 	fs, _ := NewFs("./cachex", 0700)
+	t.Cleanup(func() { os.RemoveAll("./cachex") })
 	fs.EncodeKey = IdentityCodeKey
 	fs.DecodeKey = IdentityCodeKey
 	ck, _ := NewCache(fs, NewReaper(time.Hour, time.Hour))
@@ -116,6 +118,7 @@ func TestMemFs(t *testing.T) {
 
 func TestLoadCleanup1(t *testing.T) {
 	os.Mkdir("./cache6", 0700)
+	t.Cleanup(func() { os.RemoveAll("./cache6") })
 	f, err := createFile(filepath.Join("./cache6", "s11111111"+tob64("test")))
 	if err != nil {
 		t.Error(err.Error())
@@ -159,6 +162,7 @@ func TestLoadCleanup2(t *testing.T) {
 	name1 := fmt.Sprintf("%s%s%x", longPrefix, "11111111", hash[:])
 
 	os.Mkdir("./cache7", 0700)
+	t.Cleanup(func() { os.RemoveAll("./cache7") })
 	f, err := createFile(filepath.Join("./cache7", name2))
 	if err != nil {
 		t.Error(err.Error())
@@ -263,6 +267,7 @@ func TestLRUHaunterMaxItems(t *testing.T) {
 		t.Error(err.Error())
 		t.FailNow()
 	}
+	t.Cleanup(func() { os.RemoveAll("./cache1") })
 
 	c, err := NewCacheWithHaunter(fs, NewLRUHaunterStrategy(NewLRUHaunter(3, 0, 400*time.Millisecond)))
 
@@ -319,6 +324,7 @@ func TestLRUHaunterMaxSize(t *testing.T) {
 		t.Error(err.Error())
 		t.FailNow()
 	}
+	t.Cleanup(func() { os.RemoveAll("./cache1") })
 
 	c, err := NewCacheWithHaunter(fs, NewLRUHaunterStrategy(NewLRUHaunter(0, 24, 400*time.Millisecond)))
 
@@ -370,6 +376,7 @@ func TestReaper(t *testing.T) {
 		t.Error(err.Error())
 		t.FailNow()
 	}
+	t.Cleanup(func() { os.RemoveAll("./cache1") })
 
 	c, err := NewCache(fs, NewReaper(0*time.Second, 100*time.Millisecond))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/djherbis/fscache
 
-go 1.13
+go 1.14
 
 require (
 	github.com/djherbis/atime v1.1.0

--- a/layers.go
+++ b/layers.go
@@ -71,7 +71,7 @@ func (l *layeredCache) Remove(key string) error {
 		grp.Add(1)
 		go func(layer Cache) {
 			defer grp.Done()
-			layer.Remove(key)
+			_ = layer.Remove(key)
 		}(l.layers[i])
 	}
 	grp.Wait()
@@ -87,7 +87,7 @@ func (l *layeredCache) Exists(key string) bool {
 	return false
 }
 
-func (l *layeredCache) Clean() (error) {
+func (l *layeredCache) Clean() error {
 	for _, layer := range l.layers {
 		if err := layer.Clean(); err != nil {
 			return err

--- a/server.go
+++ b/server.go
@@ -54,8 +54,8 @@ func getKey(r io.Reader) string {
 
 func sendKey(w io.Writer, key string) {
 	enc := newEncoder(w)
-	enc.Write([]byte(key))
-	enc.Close()
+	_, _ = enc.Write([]byte(key))
+	_ = enc.Close()
 }
 
 func (s *server) Serve(c net.Conn) {
@@ -66,11 +66,11 @@ func (s *server) Serve(c net.Conn) {
 	case actionGet:
 		s.get(c, getKey(c))
 	case actionRemove:
-		s.c.Remove(getKey(c))
+		_ = s.c.Remove(getKey(c))
 	case actionExists:
 		s.exists(c, getKey(c))
 	case actionClean:
-		s.c.Clean()
+		_ = s.c.Clean()
 	}
 }
 


### PR DESCRIPTION
Hi @djherbis,

I don't know if you're still maintaining this package, but I've been using it for some time a [project](https://github.com/neilotoole/sq) of my own (and it's worked great!).

I now need to fork `fscache` for my own experimental purposes, and thought I'd offer back a few repo cleanup items.

- Moved to Go `1.14` just to take advantage of `t.Cleanup`.
- Updated GH workflow to use the standard `actions/setup-go@v4`.
- Added a standard `.gitignore`.
- Add OS matrix to GH workflow `build-test` job.
  - ⚠️ Note that the `LRUHaunter` tests [fail](https://github.com/neilotoole/fscache/actions/runs/6997401294/job/19034337097) on macOS.
- Tests now clean up created cache dirs (e.g. `cache1`, `cachex`, etc.) via `t.Cleanup`; this prevents polluting the repo dir.
- Main codebase now explicitly assigns unchecked errors to `_` (although it probably should be more rigorous about returning errors).
- Re-implemented `distrib.Clean` to return the first error encountered (but attempts to clean all caches regardless).

There's a bunch more stuff that could be done to pass run-of-the-mill linting, but hopefully this is a start.

Thanks again for a great project.